### PR TITLE
Add supporters monetization (promoted box on every page)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -181,9 +181,7 @@ export default class App extends Component {
 
   getBoosts = async (tokenId) => {
     const boosts = await getBoosts(tokenId);
-    if (this.state.feedId === tokenId || (this.state.feedId === undefined && tokenId === DEFAULT_TOKEN_ID)) {
-      this.setState({ boosts });
-    }
+    this.setState({ boosts });
   };
 
   get isBoostable() {

--- a/src/Catvertised.js
+++ b/src/Catvertised.js
@@ -387,15 +387,16 @@ export default class Catvertised extends React.Component {
     step: 'catvertised',
     value: 0,
     customCatId: undefined,
+    tokenDecimals: 18 // FIXME: get token decimals from web3
   };
 
   componentDidMount() {
-    this.props.getBoosts(this.props.token);
+    this.props.getBoosts(this.props.owner);
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.token !== this.props.token) {
-      this.props.getBoosts(nextProps.token);
+    if (nextProps.owner !== this.props.owner) {
+      this.props.getBoosts(nextProps.owner);
     }
   }
 
@@ -440,20 +441,20 @@ export default class Catvertised extends React.Component {
             {this.state.step === 'catvertised' && (
               <React.Fragment>
                 <CatvertisedHeader>
-                  <Purrmoter to={`/${this.props.token}`} hiddenOnMobile>
-                    <EntityAvatar size="medium" id={this.props.token} />
+                  <Purrmoter to={`/${this.props.owner}`} hiddenOnMobile>
+                    <EntityAvatar size="medium" id={this.props.owner} />
                     <EntityDescription>
                       <CatvertisedName>
                         <EntityNameWrapper>
-                          <EntityName id={this.props.token} />
+                          <EntityName id={this.props.owner} />
                         </EntityNameWrapper>
                       </CatvertisedName>
                       <CatvertisedScore>Space Owner</CatvertisedScore>
                     </EntityDescription>
                   </Purrmoter>
                   <HeaderSplit hiddenOnMobile />
-                  <CatvertisedTitle hiddenOnMobile>Promoted</CatvertisedTitle>
-                  <AddAKitty onClick={() => this.setState({ step: 'pickCat' })}>Promote yourself</AddAKitty>
+                  <CatvertisedTitle hiddenOnMobile>Supporters</CatvertisedTitle>
+                  <AddAKitty onClick={() => this.setState({ step: 'pickCat' })}>Support this club</AddAKitty>
                 </CatvertisedHeader>
                 {Object.keys(boosts).length > 0 && (
                   <CatvertisedList>
@@ -480,19 +481,19 @@ export default class Catvertised extends React.Component {
             )}
             {this.state.step === 'pickCat' && (
               <React.Fragment>
-                <Purrmoter to={`/${this.props.token}`}>
-                  <EntityAvatar size="medium" id={this.props.token} />
+                <Purrmoter to={`/${this.props.owner}`}>
+                  <EntityAvatar size="medium" id={this.props.owner} />
                   <EntityDescription>
                     <CatvertisedName>
                       <EntityNameWrapper>
-                        <EntityName id={this.props.token} />
+                        <EntityName id={this.props.owner} />
                       </EntityNameWrapper>
                     </CatvertisedName>
                     <CatvertisedScore>Space Owner</CatvertisedScore>
                   </EntityDescription>
                 </Purrmoter>
                 <HeaderSplit />
-                <CatvertisedTitle style={{ marginTop: '10px' }}>Promote yourself</CatvertisedTitle>
+                <CatvertisedTitle style={{ marginTop: '10px' }}>Support this club</CatvertisedTitle>
                 <CatvertisedBack
                   onClick={() => {
                     this.setState({ step: 'catvertised' });
@@ -566,12 +567,12 @@ export default class Catvertised extends React.Component {
             )}
             {this.state.step === 'form' && (
               <React.Fragment>
-                <Purrmoter to={`/${this.props.token}`}>
-                  <EntityAvatar size="medium" id={this.props.token} />
+                <Purrmoter to={`/${this.props.owner}`}>
+                  <EntityAvatar size="medium" id={this.props.owner} />
                   <EntityDescription>
                     <CatvertisedName>
                       <EntityNameWrapper>
-                        <EntityName id={this.props.token} />
+                        <EntityName id={this.props.owner} />
                       </EntityNameWrapper>
                     </CatvertisedName>
                     <CatvertisedScore>Space Owner</CatvertisedScore>
@@ -600,7 +601,7 @@ export default class Catvertised extends React.Component {
                     marginTop: '20px',
                   }}
                 >
-                  Promote with
+                  Support with
                 </div>
                 <form
                   style={{ marginBottom: '-5px' }}
@@ -608,8 +609,9 @@ export default class Catvertised extends React.Component {
                     e.preventDefault();
                     const { transactionHash, networkName } = await boost(
                       this.state.entityId,
+                      this.props.owner,
                       this.props.token,
-                      this.state.value * 10 ** 18,
+                      this.state.value * 10 ** this.state.tokenDecimals,
                     );
                     this.setState({
                       etherscanUrl: createEtherscanUrl(transactionHash, networkName),
@@ -629,7 +631,7 @@ export default class Catvertised extends React.Component {
                   <Position>Position: {this.renderPosition(this.calculatePosition(boosts))}</Position>
 
                   <StyledButton disabled={!isBoostable || this.state.value <= 0}>
-                    {!isBoostable ? 'Switch to mainnet' : this.state.value <= 0 ? 'Not enough ETH' : 'Promote!'}
+                    {!isBoostable ? 'Switch to mainnet' : this.state.value <= 0 ? 'Not enough ETH' : 'Support!'}
                   </StyledButton>
                 </form>
               </React.Fragment>
@@ -661,7 +663,7 @@ export default class Catvertised extends React.Component {
                   Success!
                 </div>
                 <div style={{ fontSize: '18px' }}>
-                  You've promoted <EntityName id={this.state.entityId} />
+                  You've added <EntityName id={this.state.entityId} />
                 </div>
                 <A href={this.state.etherscanUrl}>See it on Etherscan</A>
               </div>

--- a/src/Discover.js
+++ b/src/Discover.js
@@ -30,6 +30,7 @@ import {
   IfActiveEntityHasToken,
   DoesActiveEntityHasToken,
 } from './Entity';
+import Catvertised from './Catvertised';
 
 const DiscoveryContext = React.createContext();
 
@@ -256,6 +257,13 @@ const ByToken = ({ match, token }) => (
             <Social asset={`${token.network}:${token.address}`} social="twitter" limit={2} />
             <Social asset={`${token.network}:${token.address}`} social="instagram" limit={2} />
             <Social asset={`${token.network}:${token.address}`} social="facebook" limit={2} />
+          </FlatContainer>
+          <hr/>
+          <FlatContainer>
+            <H3>VIP</H3>
+            <AppContext.Consumer>
+              {({ boostStore: { getBoosts } }) => <Catvertised token={token.is721?token.payments.token:token.network+':'+token.address} owner={token.payments.owner} getBoosts={getBoosts}/>}
+            </AppContext.Consumer>
           </FlatContainer>
         </div>
       </div>

--- a/src/IndexPage.js
+++ b/src/IndexPage.js
@@ -6,7 +6,8 @@ import Hero from './Hero';
 import { FeedCatvertised } from './Catvertised';
 import { HeaderSpacer } from './Header';
 
-const { REACT_APP_DEFAULT_TOKEN_ID: DEFAULT_TOKEN_ID } = process.env;
+const { REACT_APP_DEFAULT_OWNER: DEFAULT_OWNER } = process.env;
+const { REACT_APP_DEFAULT_TOKEN: DEFAULT_TOKEN } = process.env;
 
 export default class IndexPage extends Component {
   componentDidMount() {
@@ -26,7 +27,7 @@ export default class IndexPage extends Component {
         <HeaderSpacer />
         <Hero />
         <FeedContainer>
-          <FeedCatvertised token={DEFAULT_TOKEN_ID} />
+          <FeedCatvertised owner={DEFAULT_OWNER} token={DEFAULT_TOKEN}/>
           <ConnectedFeed className="column is-6" />
         </FeedContainer>
       </React.Fragment>

--- a/src/ShowPage.js
+++ b/src/ShowPage.js
@@ -100,7 +100,7 @@ export default class ShowPage extends Component {
                 </FlatContainer>
                 <FlatContainer style={{ marginTop: '30px' }}>
                   <AppContext.Consumer>
-                    {({ boostStore: { getBoosts } }) => <Advertised getBoosts={getBoosts} token={entityId} />}
+                    {({ boostStore: { getBoosts } }) => <Advertised getBoosts={getBoosts} owner={entityId} token="ethereum"/>}
                   </AppContext.Consumer>
                 </FlatContainer>
               </div>

--- a/src/api.js
+++ b/src/api.js
@@ -368,7 +368,7 @@ export const label = async (entity, message, labelType, { http } = {}) => {
   };
 };
 
-export const boost = async (entity, aboutEntity, value) => {
+export const boost = async (entity, aboutEntity, token, value) => {
   const { networkName } = await getWeb3State();
   const { ownerAddress } = await getEntityData(aboutEntity);
   const data = {

--- a/src/erc20.js
+++ b/src/erc20.js
@@ -90,6 +90,10 @@ const ercs20 = [
     secondaryColor: '#C23DA8',
     shadowColor: 'rgba(194,61,168,0.2)',
     is721: true,
+    payments: {
+      owner: 'ethereum:0x06012c8cf97bead5deae237070f9587f8e7a266d:1',
+      token: 'ethereum'
+    }
   },
   {
     network: 'ethereum',
@@ -102,6 +106,10 @@ const ercs20 = [
     secondaryColor: '#1D132D',
     shadowColor: 'rgba(193,205,109,0.3)',
     is721: true,
+    payments: {
+      owner: 'ethereum:0xf7a6e15dfd5cdd9ef12711bd757a9b6021abf643:1',
+      token: 'ethereum'
+    }
   },
   {
     network: 'ethereum',
@@ -114,6 +122,10 @@ const ercs20 = [
     secondaryColor: '#FFFFFF',
     shadowColor: 'rgba(224,81,184,0.3)',
     is721: true,
+    payments: {
+      owner: 'ethereum:0xa6d954d08877f8ce1224f6bfb83484c7d3abf8e9:1',
+      token: 'ethereum'
+    }
   },
   {
     network: 'ethereum',
@@ -126,6 +138,10 @@ const ercs20 = [
     secondaryColor: '#F05E40',
     shadowColor: 'rgba(247,165,148,0.3)',
     is721: true,
+    payments: {
+      owner: 'ethereum:0x323a3e1693e7a0959f65972f3bf2dfcb93239dfe:1',
+      token: 'ethereum'
+    }
   },
   {
     network: 'ethereum',
@@ -138,6 +154,10 @@ const ercs20 = [
     secondaryColor: '#ffffff',
     shadowColor: 'rgba(200,249,255,0.6)',
     is721: true,
+    payments: {
+      owner: 'ethereum:0xdde2d979e8d39bb8416eafcfc1758f3cab2c9c72:1',
+      token: 'ethereum'
+    }
   },
   {
     network: 'ethereum',
@@ -150,6 +170,10 @@ const ercs20 = [
     secondaryColor: '#2D1F18',
     shadowColor: 'rgba(190,196,203,0.4)',
     is721: true,
+    payments: {
+      owner: 'ethereum:0xdcaad9fd9a74144d226dbf94ce6162ca9f09ed7e:1',
+      token: 'ethereum'
+    }
   },
   {
     network: 'ethereum',
@@ -162,6 +186,10 @@ const ercs20 = [
     secondaryColor: '#283861',
     shadowColor: 'rgba(118,103,170,0.26)',
     is721: true,
+    payments: {
+      owner: 'ethereum:0x4fece400c0d3db0937162ab44bab34445626ecfe:1',
+      token: 'ethereum'
+    }
   },
   {
     network: 'ethereum',
@@ -174,6 +202,10 @@ const ercs20 = [
     secondaryColor: '#FCE478',
     shadowColor: 'rgba(52,58,64,0.2)',
     is721: true,
+    payments: {
+      owner: 'ethereum:0x71c118b00759b0851785642541ceb0f4ceea0bd5:1',
+      token: 'ethereum'
+    }
   },
   {
     network: 'ethereum',
@@ -186,6 +218,10 @@ const ercs20 = [
     secondaryColor: '#030F23',
     shadowColor: 'rgba(186,210,237,0.3)',
     is721: true,
+    payments: {
+      owner: 'ethereum:0x87d598064c736dd0c712d329afcfaa0ccc1921a1:1',
+      token: 'ethereum'
+    }
   },
   {
     network: 'ethereum',
@@ -198,6 +234,10 @@ const ercs20 = [
     secondaryColor: '#382320',
     shadowColor: 'rgba(216,206,203,0.6)',
     is721: true,
+    payments: {
+      owner: 'ethereum:0xabc7e6c01237e8eef355bba2bf925a730b714d5f:1',
+      token: 'ethereum'
+    }
   },
   {
     network: 'ethereum',
@@ -210,6 +250,10 @@ const ercs20 = [
     secondaryColor: '#ffffff',
     shadowColor: 'rgba(1,2,6,0.2)',
     is721: true,
+    payments: {
+      owner: 'ethereum:0xb2c0782ae4a299f7358758b2d15da9bf29e1dd99:1',
+      token: 'ethereum'
+    }
   },
   {
     network: 'ethereum',
@@ -222,6 +266,10 @@ const ercs20 = [
     secondaryColor: '#F7DC8D',
     shadowColor: 'rgba(75,30,6,0.4)',
     is721: true,
+    payments: {
+      owner: 'ethereum:0xc70be5b7c19529ef642d16c10dfe91c58b5c3bf0:1',
+      token: 'ethereum'
+    }
   },
   {
     network: 'ethereum',
@@ -234,6 +282,10 @@ const ercs20 = [
     secondaryColor: '#332f2c',
     shadowColor: 'rgba(51,47,44,0.1)',
     is721: true,
+    payments: {
+      owner: 'ethereum:0x663e4229142a27f00bafb5d087e1e730648314c3:1',
+      token: 'ethereum'
+    }
   },
   {
     network: 'ethereum',
@@ -245,6 +297,9 @@ const ercs20 = [
     primaryColor: '#CDFA7F',
     secondaryColor: '#3D5000',
     shadowColor: 'rgba(61,80,0,0.2)',
+    payments: {
+      owner: 'ethereum:0x06012c8cf97bead5deae237070f9587f8e7a266d:134330',
+    }
   },
   /*{
     network: 'ethereum',
@@ -267,6 +322,9 @@ const ercs20 = [
     primaryColor: '#BEC4CB',
     secondaryColor: '#2D1F18',
     shadowColor: 'rgba(88,66,54,0.25)',
+    payments: {
+      owner: 'ethereum:0x06012c8cf97bead5deae237070f9587f8e7a266d:134330',
+    }
   },
   {
     network: 'ethereum',
@@ -278,6 +336,9 @@ const ercs20 = [
     primaryColor: '#1F1826',
     secondaryColor: '#30D7A9',
     shadowColor: 'rgba(31,24,38,0.3)',
+    payments: {
+      owner: 'ethereum:0x06012c8cf97bead5deae237070f9587f8e7a266d:134330',
+    }
   },
   {
     network: 'ethereum',
@@ -289,6 +350,9 @@ const ercs20 = [
     primaryColor: '#C6FFF4',
     secondaryColor: '#276C5E',
     shadowColor: 'rgba(82,211,185,0.3)',
+    payments: {
+      owner: 'ethereum:0x06012c8cf97bead5deae237070f9587f8e7a266d:134330',
+    }
   },
   /*{
     network: 'ethereum',
@@ -300,6 +364,9 @@ const ercs20 = [
     primaryColor: '#002D64',
     secondaryColor: '#ffffff',
     shadowColor: 'rgba(31,54,90,0.5)',
+    payments: {
+      owner: 'ethereum:0x06012c8cf97bead5deae237070f9587f8e7a266d:134330',
+    }
   },*/
   {
     network: 'ethereum',
@@ -311,6 +378,9 @@ const ercs20 = [
     primaryColor: '#1A52EF',
     secondaryColor: '#ffffff',
     shadowColor: 'rgba(26,82,239,0.3)',
+    payments: {
+      owner: 'ethereum:0x06012c8cf97bead5deae237070f9587f8e7a266d:134330',
+    }
   },
   {
     network: 'ethereum',
@@ -322,6 +392,9 @@ const ercs20 = [
     primaryColor: '#C8F9FF',
     secondaryColor: '#5B3D9D',
     shadowColor: 'rgba(200,249,255,0.6)',
+    payments: {
+      owner: 'ethereum:0x06012c8cf97bead5deae237070f9587f8e7a266d:134330',
+    }
   },
   /*{
     network: 'ethereum',
@@ -333,6 +406,9 @@ const ercs20 = [
     primaryColor: '#5B6CEE',
     secondaryColor: '#ffffff',
     shadowColor: 'rgba(91,108,238,0.5)',
+    payments: {
+      owner: 'ethereum:0x06012c8cf97bead5deae237070f9587f8e7a266d:134330',
+    }
   },*/
   /*{
     network: 'ethereum',
@@ -344,6 +420,9 @@ const ercs20 = [
     primaryColor: '#3C3C3C',
     secondaryColor: '#ffffff',
     shadowColor: 'rgba(60,60,60,0.5)',
+    payments: {
+      owner: 'ethereum:0x06012c8cf97bead5deae237070f9587f8e7a266d:134330',
+    }
   },*/
   {
     network: 'ethereum',
@@ -355,6 +434,9 @@ const ercs20 = [
     primaryColor: '#C8D5FF',
     secondaryColor: '#1639AA',
     shadowColor: 'rgba(22,57,170,0.2)',
+    payments: {
+      owner: 'ethereum:0x06012c8cf97bead5deae237070f9587f8e7a266d:134330',
+    }
   },
   {
     network: 'ethereum',
@@ -366,6 +448,9 @@ const ercs20 = [
     primaryColor: '#9AF6E1',
     secondaryColor: '#1F987B',
     shadowColor: 'rgba(31,152,123,0.2)',
+    payments: {
+      owner: 'ethereum:0x06012c8cf97bead5deae237070f9587f8e7a266d:134330',
+    }
   },
   {
     network: 'ethereum',
@@ -377,6 +462,9 @@ const ercs20 = [
     primaryColor: '#C8F9FF',
     secondaryColor: '#5B3D9D',
     shadowColor: 'rgba(200,249,255,0.6)',
+    payments: {
+      owner: 'ethereum:0x06012c8cf97bead5deae237070f9587f8e7a266d:134330',
+    }
   },
 ];
 


### PR DESCRIPTION
@jakubsta The idea behind this PR is that we should have `Promoted/Supporters` box on every page.

- On ERC721 club page - The promoted box will receive ETH and you can put any ERC721 character that belongs to this club. Later we will allow some kind of customization so that Each ERC721 club can set what token they want to receive.
- On ERC20 club page - The promoted box will accept only this ERC20 token as payment. And allow any ERC721/address to promote itself/support give club.
- On ERC721/Address Profile page - For now profile pages will accept ETH and allow any ERC721/address. We will add token customization later on.

I've added initial support for ETH on ERC721 club pages and profile pages but need help with adding support for ERC20 as payment.

(We will also need to contact all those projects so that we can set proper receiving addresses.) 