### PR TITLE
ShowPage link fix

### DIFF
--- a/src/ShowPage.js
+++ b/src/ShowPage.js
@@ -295,14 +295,14 @@ const ExitIcon = styled.img.attrs({ src: closeIcon })`
 
 class EditableLabel extends Component {
   static DOMAIN_REGEX = {
-    facebook: /^(?:(?:https?:\/\/)?(?:www\.)?facebook\.com\/)?([\w.-]+)$/,
-    twitter: /^(?:(?:https?:\/\/)?(?:www\.)?twitter\.com\/)?([\w]+)$/,
-    github: /^(?:(?:https?:\/\/)?(?:www\.)?github\.com\/)?([\w-+@]+)$/,
-    instagram: /^(?:(?:https?:\/\/)?(?:www\.)?instagram\.com\/)?([\w.-]+)$/,
+    facebook: /^(?:(?:http|https):\/\/)?(?:www\.)?(?:facebook|fb).com\/([\w.-]+)$/,
+    twitter: /^(?:(?:http|https):\/\/)?(?:www\.)?twitter\.com\/)?([\w]+)$/,
+    github: /^(?:(?:http|https):\/\/)?(?:www\.)?github\.com\/)?([\w-+@]+)$/,
+    instagram: /^(?:(?:http|https):\/\/)?(?:www\.)?instagram\.com\/)?([\w.-]+)$/,
   };
   static DOMAINS = {
-    facebook: 'https://facebook/',
-    twitter: 'https://twitter/',
+    facebook: 'https://facebook.com/',
+    twitter: 'https://twitter.com/',
     github: 'https://github.com/',
     instagram: 'https://instagram.com/',
   };


### PR DESCRIPTION
- Solve missing .com problem for FB and Twitter link
- Update REGEX to support http and fb.com link